### PR TITLE
Update readme.md

### DIFF
--- a/agents/qodo-merge-post-commit/readme.md
+++ b/agents/qodo-merge-post-commit/readme.md
@@ -4,19 +4,24 @@ This README explains how to **automatically** receive code suggestions from Qodo
 
 ## Setup Instructions
 
-### 1. Ensure `pre-commit` is Installed
+### 1. Setup Qodo Gen CLI
 
-Install `pre-commit` if you haven't already:
+See [here](https://github.com/qodo-ai/qodo-gen-cli?tab=readme-ov-file#installation) for instructions.
+
+
+### 2. Install `pre-commit` Pip Package
 
 ```bash
 pip install pre-commit
 ```
 
-### 2. Copy Configuration Files
+This package will enable running pre (and post) commits on your local IDE.
+
+### 3. Copy Configuration Files
 
 Copy the `.pre-commit-config.yaml` and `agent.toml` files from the `agents/qodo-merge-post-commit/` directory to the root of your repository. These files contain the configuration for the pre-commit hooks that will run after each commit.
 
-### 3. Install the Post-Commit Hooks
+### 4. Install the Post-Commit Hooks
 
 Run the following command in your terminal to install the hooks specified in your configuration file:
 
@@ -26,7 +31,7 @@ pre-commit install --hook-type post-commit
 
 This command sets up the hooks to run automatically after each commit.
 
-### 4. You're All Set!
+### 5. You're All Set!
 
 Now, every time you make a commit, Qodo Merge will automatically run in the background. When it finishes (usually takes ~30 seconds), it will generate a file called `diff_review_post_commit.md` in the root of your repository, containing code suggestions for changes in your current branch compared to the main branch.
 


### PR DESCRIPTION
I want the readme to be fully _self-contained_. i am linking it from Qodo Merge docs

 https://qodo-merge-docs.qodo.ai/recent_updates/

### **PR Type**
Documentation


___

### **Description**
- Added Qodo Gen CLI setup as prerequisite step

- Clarified pre-commit package installation purpose

- Renumbered setup instructions for better flow


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Setup Instructions"] --> B["1. Setup Qodo Gen CLI"]
  B --> C["2. Install pre-commit"]
  C --> D["3. Copy Config Files"]
  D --> E["4. Install Hooks"]
  E --> F["5. Ready to Use"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>readme.md</strong><dd><code>Enhanced setup instructions with CLI prerequisite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents/qodo-merge-post-commit/readme.md

<li>Added new step 1 for Qodo Gen CLI setup with installation link<br> <li> Enhanced pre-commit installation description with purpose explanation<br> <li> Renumbered all subsequent setup steps (2-5) for proper sequence


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/agents/pull/4/files#diff-7d270df56bfee1a0caceeb990be4b261ba48f8e8fabaefb60cba32bff6ab24b2">+11/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>