### PR TITLE
fix: update mcp tools usage

### DIFF
--- a/agents/openssf-scorecard-fixer/agent.yaml
+++ b/agents/openssf-scorecard-fixer/agent.yaml
@@ -46,6 +46,7 @@ commands:
       - filesystem
       - shell
       - github
+      - web_search
 
     execution_strategy: plan
     
@@ -60,22 +61,10 @@ commands:
               "ALLOW_COMMANDS": "scorecard,docker,env,ls,cat,pwd,rg,wc,touch,find,mkdir,rm,cp,mv,npm,npx,jest,mocha,ts-node,tsc,node,jq,echo,test,diff,sed,awk,git,cd,exit,yarn,grep,gh,base64,curl,python3,python,pip,pip3,which,whoami,id,uname,date,head,tail,sort,uniq,tr,cut,xargs,sleep"
             }
           },
-          "fetch": {
-            "command": "docker",
-            "args": ["run", "-i", "--rm", "mcp/fetch"]
-          },
           "github": {
-            "command": "docker",
-            "args": [
-              "run",
-              "-i",
-              "--rm",
-              "-e",
-              "GITHUB_PERSONAL_ACCESS_TOKEN",
-              "ghcr.io/github/github-mcp-server"
-            ],
-            "env": {
-              "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOR_TOKEN>"
+            "url": "https://api.githubcopilot.com/mcp/",
+            "headers": {
+              "Authorization": "Bearer ${GITHUB_PERSONAL_ACCESS_TOKEN}"
             }
           }
       }
@@ -91,7 +80,7 @@ commands:
          - For all GitHub operations, prefer using the GitHub CLI (`gh`) commands over the GitHub MCP server when encountering API limitations
          - If GitHub MCP server operations fail, clone the repository locally using `git clone` and work with local files
          - To run the OpenSSF Scorecard tool, use: `scorecard --repo=<INSERT REPO> --show-details` (replace with the repository from the `repo` argument)
-         - You can get information from URLs using the fetch tool
+         - You can get information from URLs using the web_fetch tool
          - For base64 decoding, use: `echo "<base64_string>" | base64 -d` or Node.js: `node -e "console.log(Buffer.from('<base64>', 'base64').toString())"`
          - Always verify GitHub CLI authentication with `gh auth status` before attempting operations
          - Use `gh api` for direct GitHub API calls when the MCP server fails


### PR DESCRIPTION
### **User description**
This PR addresses suggestions from prior PR that improves:
- Uses the GitHub remote MCP so that it doesn't require Docker present or installed
- Relies on the built-in `web_search` MCP Server that exposes a `web_fetch` tool and instructions are updated to communicate that to the agent


___

### **PR Type**
Enhancement


___

### **Description**
- Replace Docker-based MCP servers with remote alternatives

- Add web_search tool for URL fetching capabilities

- Update GitHub MCP server to use remote API

- Simplify tool configuration and remove Docker dependencies


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Docker MCP Servers"] --> B["Remote MCP Servers"]
  C["fetch tool"] --> D["web_search tool"]
  E["Local GitHub MCP"] --> F["Remote GitHub API"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agent.yaml</strong><dd><code>Update MCP server configuration and tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

agents/openssf-scorecard-fixer/agent.yaml

<li>Added <code>web_search</code> to available_tools list<br> <li> Removed Docker-based <code>fetch</code> MCP server configuration<br> <li> Updated GitHub MCP server to use remote API endpoint<br> <li> Changed tool reference from <code>fetch</code> to <code>web_fetch</code> in instructions


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/agents/pull/14/files#diff-a2c604e66fcc9293aaf94caf0ea374d37f0f4a8ef918688d592d7848d66d0f5c">+5/-16</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>