### PR TITLE
docs(contributing): fix incorrect upstream URL in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ This project adheres to a code of conduct that we expect all contributors to fol
    ```
 3. **Set up the upstream remote**:
    ```bash
-   git remote add upstream https://github.com/qodo-dev/agents.git
+   git remote add upstream https://github.com/qodo-ai/agents.git
    ```
 
 ## How to Contribute


### PR DESCRIPTION
### **User description**
## Description
This PR basically fixes issue: #37  an incorrect upstream URL mentioned in the contributing guidelines.

## Update
Updating `upstream URL` ensures that new contributors can correctly set up their upstream remotes, stay in sync with the main repository, and follow the proper contribution workflow.
```
// BEFORE 
git remote add upstream https://github.com/qodo-dev/agents.git


// AFTER 
git remote add upstream https://github.com/qodo-ai/agents.git
```


Fixes #37


___

### **PR Type**
Documentation


___

### **Description**
- Fix incorrect upstream URL in contributing guide

- Update repository reference from qodo-dev to qodo-ai


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CONTRIBUTING.md"] --> B["Update upstream URL"]
  B --> C["qodo-dev/agents.git → qodo-ai/agents.git"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CONTRIBUTING.md</strong><dd><code>Fix upstream repository URL reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CONTRIBUTING.md

<ul><li>Update upstream remote URL from <code>qodo-dev</code> to <code>qodo-ai</code><br> <li> Fix repository reference in git setup instructions</ul>


</details>


  </td>
  <td><a href="https://github.com/qodo-ai/agents/pull/38/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

