### PR TITLE
chore: add Dependency Guard workflow (alpha)

### DIFF
--- a/.github/workflows/dependency-guard-prepare.yml
+++ b/.github/workflows/dependency-guard-prepare.yml
@@ -1,0 +1,39 @@
+name: Dependency Guard (Prepare)
+
+# Triggered by pull_request — runs without secrets, safe for fork PRs.
+# Saves PR metadata as an artifact consumed by the scan workflow.
+# No code from the fork is executed here.
+on:
+  pull_request:
+    paths:
+      - '**/package-lock.json'
+      - '**/yarn.lock'
+      - '**/pnpm-lock.yaml'
+      - '**/requirements.txt'
+      - '**/requirements*.txt'
+      - '**/poetry.lock'
+      - '**/Pipfile.lock'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Save PR metadata
+        run: |
+          mkdir -p artifacts
+          printf '%s' "${{ github.event.pull_request.number }}" > artifacts/pr-number.txt
+          printf '%s' "${{ github.event.pull_request.head.sha }}" > artifacts/head-sha.txt
+          printf '%s' "${{ github.event.pull_request.base.ref }}" > artifacts/base-ref.txt
+          printf '%s' "${{ github.repository }}" > artifacts/repo.txt
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: dependency-guard-context
+          path: artifacts/
+          retention-days: 1

--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -17,20 +17,19 @@ concurrency:
 
 jobs:
   scan:
+    # Skip for fork PRs (no access to secrets) and when QODO_API_KEY is not set.
+    # Shows as "skipped" in the UI rather than failing hard with a red check.
+    if: >-
+      ${{
+        secrets.QODO_API_KEY != '' &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write
     steps:
-      - name: Check QODO_API_KEY is set
-        run: |
-          if [ -z "${{ secrets.QODO_API_KEY }}" ]; then
-            echo "::error::QODO_API_KEY secret is not set. Add it at:"
-            echo "::error::https://github.com/${{ github.repository }}/settings/secrets/actions/new"
-            exit 1
-          fi
-
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -1,5 +1,11 @@
 name: Dependency Guard
 
+# Triggers on dependency file changes (lockfiles + spec files like requirements*.txt).
+# NOTE: Uses pull_request (not pull_request_target). Fork PRs cannot receive secrets
+# under this trigger, so the scan is intentionally skipped for fork PRs via the
+# job-level condition below. For repos with external contributors, migrate to the
+# workflow_run two-workflow pattern to safely scan fork PRs with secrets.
+# Tracked: https://github.com/qodo-ai/dependency-guard/issues (future work)
 on:
   pull_request:
     paths:
@@ -17,8 +23,8 @@ concurrency:
 
 jobs:
   scan:
-    # Skip for fork PRs (no access to secrets) and when QODO_API_KEY is not set.
-    # Shows as "skipped" in the UI rather than failing hard with a red check.
+    # Skip for fork PRs (secrets unavailable under pull_request trigger) and
+    # when QODO_API_KEY is not configured. Shows as "skipped", not failed.
     if: >-
       ${{
         secrets.QODO_API_KEY != '' &&

--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -1,47 +1,59 @@
 name: Dependency Guard
 
-# Triggers on dependency file changes (lockfiles + spec files like requirements*.txt).
-# NOTE: Uses pull_request (not pull_request_target). Fork PRs cannot receive secrets
-# under this trigger, so the scan is intentionally skipped for fork PRs via the
-# job-level condition below. For repos with external contributors, migrate to the
-# workflow_run two-workflow pattern to safely scan fork PRs with secrets.
-# Tracked: https://github.com/qodo-ai/dependency-guard/issues (future work)
+# Triggered by the prepare workflow completing — runs in the BASE repo
+# context so QODO_API_KEY and pull-requests: write are always available,
+# including for fork PRs. This is the safe workflow_run pattern.
 on:
-  pull_request:
-    paths:
-      - '**/package-lock.json'
-      - '**/yarn.lock'
-      - '**/pnpm-lock.yaml'
-      - '**/requirements.txt'
-      - '**/requirements*.txt'
-      - '**/poetry.lock'
-      - '**/Pipfile.lock'
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
+  workflow_run:
+    workflows: ["Dependency Guard (Prepare)"]
+    types: [completed]
 
 jobs:
   scan:
-    # Skip for fork PRs (secrets unavailable under pull_request trigger) and
-    # when QODO_API_KEY is not configured. Shows as "skipped", not failed.
-    if: >-
-      ${{
-        secrets.QODO_API_KEY != '' &&
-        github.event.pull_request.head.repo.full_name == github.repository
-      }}
+    # Only proceed when the prepare workflow succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write
+      actions: read  # required to download artifacts from a workflow_run
+
     steps:
+      - name: Download PR context
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
+        with:
+          name: dependency-guard-context
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read PR metadata
+        id: pr
+        run: |
+          echo "number=$(cat pr-number.txt)"   >> "$GITHUB_OUTPUT"
+          echo "sha=$(cat head-sha.txt)"       >> "$GITHUB_OUTPUT"
+          echo "base_ref=$(cat base-ref.txt)"  >> "$GITHUB_OUTPUT"
+          echo "repo=$(cat repo.txt)"          >> "$GITHUB_OUTPUT"
+
+      # Check out the base repo with full history, then fetch the PR's
+      # exact head commit so git diff origin/<base>...HEAD works correctly.
+      # This does bring in fork code but does NOT execute it — the action
+      # only reads lockfiles and downloads packages from public registries.
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Fetch PR head commit
+        run: |
+          git fetch origin refs/pull/${{ steps.pr.outputs.number }}/head:pr-head
+          git checkout pr-head
 
       - uses: qodo-ai/dependency-guard@6b89a7045e79580127903cf1161b49ee6864ae9f  # v1.0.0-alpha.1
         with:
           qodo-api-key: ${{ secrets.QODO_API_KEY }}
+        env:
+          GH_PR_NUMBER: ${{ steps.pr.outputs.number }}
+          GH_REPO:      ${{ steps.pr.outputs.repo }}
+          GH_BASE_REF:  ${{ steps.pr.outputs.base_ref }}
+          GH_HEAD_REF:  pr-head

--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -1,0 +1,25 @@
+name: Dependency Guard
+
+on:
+  pull_request:
+    paths:
+      - '**/package-lock.json'
+      - '**/yarn.lock'
+      - '**/pnpm-lock.yaml'
+      - '**/requirements.txt'
+      - '**/requirements*.txt'
+      - '**/poetry.lock'
+      - '**/Pipfile.lock'
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: qodo-ai/dependency-guard@v1
+        with:
+          qodo-api-key: ${{ secrets.QODO_API_KEY }}
+

--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: write
@@ -33,6 +34,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
           persist-credentials: false
 
       - uses: qodo-ai/dependency-guard@6b89a7045e79580127903cf1161b49ee6864ae9f  # v1.0.0-alpha.1

--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -12,7 +12,7 @@ on:
       - '**/Pipfile.lock'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -32,6 +32,7 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - uses: qodo-ai/dependency-guard@6b89a7045e79580127903cf1161b49ee6864ae9f  # v1.0.0-alpha.1

--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -11,6 +11,11 @@ on:
       - '**/poetry.lock'
       - '**/Pipfile.lock'
 
+# Cancel in-progress scans on the same branch when new commits are pushed
+concurrency:
+  group: dependency-guard-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   scan:
     runs-on: ubuntu-latest
@@ -18,8 +23,16 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: qodo-ai/dependency-guard@v1
+      - name: Check QODO_API_KEY is set
+        run: |
+          if [ -z "${{ secrets.QODO_API_KEY }}" ]; then
+            echo "::error::QODO_API_KEY secret is not set. Add it at:"
+            echo "::error::https://github.com/${{ github.repository }}/settings/secrets/actions/new"
+            exit 1
+          fi
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - uses: qodo-ai/dependency-guard@6b89a7045e79580127903cf1161b49ee6864ae9f  # v1.0.0-alpha.1
         with:
           qodo-api-key: ${{ secrets.QODO_API_KEY }}
-

--- a/.github/workflows/dependency-guard.yml
+++ b/.github/workflows/dependency-guard.yml
@@ -11,9 +11,8 @@ on:
       - '**/poetry.lock'
       - '**/Pipfile.lock'
 
-# Cancel in-progress scans on the same branch when new commits are pushed
 concurrency:
-  group: dependency-guard-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -32,6 +31,8 @@ jobs:
           fi
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
 
       - uses: qodo-ai/dependency-guard@6b89a7045e79580127903cf1161b49ee6864ae9f  # v1.0.0-alpha.1
         with:


### PR DESCRIPTION
Adds supply-chain security scanning via [qodo-ai/dependency-guard](https://github.com/qodo-ai/dependency-guard).

Fires on PRs that change lockfiles. Posts a verdict comment (SAFE / WARNING / MALICIOUS).

**Setup required:** Add `QODO_API_KEY` secret in repo settings before merging.

Alpha — GitHub only, comment-only (no merge blocking yet).